### PR TITLE
Update Gradle wrapper and repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ minecraft.accessTransformers.file file('src/main/resources/META-INF/accesstransf
 repositories {
     mavenLocal()
     maven { url = 'https://maven.neoforged.net/releases' }
+    maven { url = 'https://libraries.minecraft.net' }
     mavenCentral()
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- bump the Gradle wrapper to 8.13 to align with the NeoForge toolchain requirements
- add the Minecraft libraries repository to the build script for resolving Mojang artifacts

## Testing
- `./gradlew clean build --console=plain` *(fails: NeoGradle plugin cannot add its required project repositories when settings.gradle enforces FAIL_ON_PROJECT_REPOS)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdc9baa288327930383e1c5246dad