### PR TITLE
Update NeoGradle configuration for 1.21.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,9 @@ java {
     withSourcesJar()
 }
 
-minecraft.accessTransformers.file file('src/main/resources/META-INF/accesstransformer.cfg') // ok if file missing
-
 repositories {
     mavenLocal()
     maven { url = 'https://maven.neoforged.net/releases' }
-    maven { url = 'https://libraries.minecraft.net' }
     mavenCentral()
 }
 
@@ -32,22 +29,27 @@ tasks.withType(JavaCompile).configureEach {
     options.release = 21
 }
 
-userdev {
-    mappings = "${property('mappings_channel')}_${property('mappings_version')}"
-    runs {
-        client {
-            client()
-            workingDirectory project.layout.projectDirectory.dir("run").asFile
-            systemProperty 'neoforge.enabledGameTestNamespaces', property('mod_id')
-            modSource project.sourceSets.main
-        }
-        server {
-            server()
-            workingDirectory project.layout.projectDirectory.dir("run-server").asFile
-            systemProperty 'neoforge.enabledGameTestNamespaces', property('mod_id')
-            modSource project.sourceSets.main
-        }
+// Configure NeoGradle extensions
+minecraft {
+    modIdentifier property('mod_id')
+    mappings {
+        channel(minecraft.namingChannels.named(property('mappings_channel')).get())
+        version property('mappings_version')
     }
+}
+
+runs.named('client') {
+    runType 'client'
+    workingDirectory project.layout.projectDirectory.dir('run')
+    systemProperty 'neoforge.enabledGameTestNamespaces', property('mod_id')
+    modSource sourceSets.main
+}
+
+runs.named('server') {
+    runType 'server'
+    workingDirectory project.layout.projectDirectory.dir('run-server')
+    systemProperty 'neoforge.enabledGameTestNamespaces', property('mod_id')
+    modSource sourceSets.main
 }
 
 tasks.jar {

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ pluginManagement {
     }
 }
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
     repositories {
         mavenLocal()
         maven { url = 'https://maven.neoforged.net/releases' }


### PR DESCRIPTION
## Summary
- switch dependency resolution to prefer project repositories to align with NeoGradle defaults
- configure the NeoGradle minecraft extension and existing run configurations for the netherportalnomore mod id
- drop the unused access transformer reference and the obsolete userdev block from build.gradle

## Testing
- `./gradlew clean build` *(fails: unable to download Minecraft asset files from resources.download.minecraft.net)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdf74d68c832782ee89441f7ab546