### PR TITLE
Improve portal cancellation for NeoForge 1.21.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Netherportalnomore
 
 No More Nether Portal was created by Gigabit101 to address an issue in Monumental Experience where Nether portals were being created through various means—such as world generation, portal lighting, and more. This mod prevents unwanted portal creation while still allowing access to the Nether through the Dim Paintings Nether Painting, giving you better control over dimension travel.
+
+This branch targets **Minecraft 1.21.1** with **NeoForge 21.1.209+**, ensuring portal suppression continues to work on the latest toolchain.

--- a/src/main/java/com/cyberday1/netherportalnomore/PortalBlocker.java
+++ b/src/main/java/com/cyberday1/netherportalnomore/PortalBlocker.java
@@ -1,5 +1,6 @@
 package com.cyberday1.netherportalnomore;
 
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.Items;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -19,6 +20,7 @@ public final class PortalBlocker {
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
         if (event.getItemStack().is(Items.FLINT_AND_STEEL)) {
+            event.setCancellationResult(InteractionResult.FAIL);
             event.setCanceled(true);
         }
     }


### PR DESCRIPTION
## Summary
- document the Minecraft 1.21.1 and NeoForge 21.1.209 target in the project readme
- ensure flint and steel cancellation fails interaction as well as cancelling the event for NeoForge 1.21.1

## Testing
- `./gradlew build --console=plain` *(fails: neoFormMerge expects stripServer/stripClient outputs that are not generated by the toolchain in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe4ad5dc0832794b37d597615d9ff