### PR TITLE
Improve portal prevention for NeoForge 1.21.1

### DIFF
--- a/src/main/java/com/cyberday1/netherportalnomore/PortalBlocker.java
+++ b/src/main/java/com/cyberday1/netherportalnomore/PortalBlocker.java
@@ -1,11 +1,16 @@
 package com.cyberday1.netherportalnomore;
 
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.InteractionResult;
-import net.minecraft.world.item.Items;
+import net.minecraft.world.item.FireChargeItem;
+import net.minecraft.world.item.FlintAndSteelItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.common.Tags;
 
 @EventBusSubscriber(modid = NetherPortalNoMore.MODID)
 public final class PortalBlocker {
@@ -19,9 +24,26 @@ public final class PortalBlocker {
 
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (event.getItemStack().is(Items.FLINT_AND_STEEL)) {
+        if (event.getLevel().isClientSide()) {
+            return;
+        }
+
+        if (isPortalLightingItem(event.getItemStack())) {
             event.setCancellationResult(InteractionResult.FAIL);
             event.setCanceled(true);
         }
+    }
+
+    private static boolean isPortalLightingItem(ItemStack stack) {
+        if (stack.isEmpty()) {
+            return false;
+        }
+
+        if (stack.is(ItemTags.CREEPER_IGNITERS) || stack.is(Tags.Items.TOOLS_IGNITER)) {
+            return true;
+        }
+
+        Item item = stack.getItem();
+        return item instanceof FlintAndSteelItem || item instanceof FireChargeItem;
     }
 }

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,3 +1,3 @@
 {
-  "pack": { "pack_format": 34, "description": "NetherPortalNoMore resources" }
+  "pack": { "pack_format": 48, "description": "NetherPortalNoMore resources" }
 }


### PR DESCRIPTION
## Summary
- broaden the portal lighting guard to cover tagged igniters and fire charges while skipping client-side handling
- bump the resource pack metadata to the 1.21.1 pack format

## Testing
- ./gradlew compileJava --console=plain --quiet

------
https://chatgpt.com/codex/tasks/task_e_68dbe85b6dbc8327a86d80e69387f634