### PR TITLE
Update run configuration for NeoForge 1.21.1 DSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,21 +29,19 @@ tasks.withType(JavaCompile).configureEach {
     options.release = 21
 }
 
-userdev {
-    mappings = "${property('mappings_channel')}_${property('mappings_version')}"
-    runs {
-        client {
-            client()
-            workingDirectory project.layout.projectDirectory.dir("run").asFile
-            systemProperty 'neoforge.enabledGameTestNamespaces', property('mod_id')
-            modSource project.sourceSets.main
-        }
-        server {
-            server()
-            workingDirectory project.layout.projectDirectory.dir("run-server").asFile
-            systemProperty 'neoforge.enabledGameTestNamespaces', property('mod_id')
-            modSource project.sourceSets.main
-        }
+userDevRuntime {
+    runs.configureEach {
+        modSource project.sourceSets.main
+    }
+
+    runs.named("client").configure {
+        workingDirectory.set(project.layout.projectDirectory.dir("run"))
+        systemProperties.put('neoforge.enabledGameTestNamespaces', project.property('mod_id'))
+    }
+
+    runs.named("server").configure {
+        workingDirectory.set(project.layout.projectDirectory.dir("run-server"))
+        systemProperties.put('neoforge.enabledGameTestNamespaces', project.property('mod_id'))
     }
 }
 


### PR DESCRIPTION
## Summary
- switch the build script to the new `userDevRuntime` DSL for NeoForge 1.21.1
- ensure client and server run configurations include the main sources, working directories, and game test namespace property

## Testing
- `./gradlew jar --console=plain`
- `./gradlew runClient --console=plain` *(fails: requires a graphical environment in this container)*
- `./gradlew runServer --console=plain` *(terminated early in the headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbedee15388327aafa814b1e64f7b1